### PR TITLE
fix(workflow): improve Windows build error handling and sidecar requi…

### DIFF
--- a/.github/workflows/build-bundles.yml
+++ b/.github/workflows/build-bundles.yml
@@ -85,8 +85,8 @@ jobs:
       with:
         python-version: '3.8'
 
-    - name: Install Visual Studio Build Tools
-      uses: microsoft/setup-msbuild@v2
+    - name: Setup MSVC Developer Command Prompt  
+      uses: ilammy/msvc-dev-cmd@v1
       
     - name: Install prerequisites  
       run: |
@@ -118,11 +118,6 @@ jobs:
       run: |
         cd app\bundles\desktop
         powershell -ExecutionPolicy Bypass -File .\build-windows-bundle.ps1
-        
-    - name: List created files
-      run: |
-        cd app\bundles\desktop
-        dir *.exe, *.msi
         
     - name: Upload Windows installers
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
…rements

- Replace microsoft/setup-msbuild@v2 with ilammy/msvc-dev-cmd@v1 for full compiler environment
- Remove optional SkipSidecar parameter - sidecar is always required
- Add proper exit code checking for cargo tauri commands
- Ensure PowerShell script fails on sidecar compilation errors